### PR TITLE
fix the double dot in the extension generated name

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -35,7 +35,7 @@ if env["platform"] == "macos":
 	)
 else:
 	library = env.SharedLibrary(
-		"bin/addons/godot-rapier2d/bin/libphysics_server_rapier2d.{}{}".format(env["suffix"], env["SHLIBSUFFIX"]),
+		"bin/addons/godot-rapier2d/bin/libphysics_server_rapier2d{}{}".format(env["suffix"], env["SHLIBSUFFIX"]),
 		source=sources,
 	)
 


### PR DESCRIPTION
@Ughuuu I noticed that there was a colon in the name of all extensions except macOS.

`env["suffix"]` already includes the point in the variable ( like `.windows.template_debug.dev.x86_64`)