### PR TITLE
Change capsule to basic shapes. Add basic implementation for conveyer belt. Make static bodies be kinematic instead.

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -68,7 +68,6 @@ The library files will be found in `bin/addons/` folder.
 ### Step 1
 
 We check if the body + margin collide something:
-![Body Test Motion Step 1](docs/test_body_motion_step_1.png)
 - if true: 
     
     we loop 4 times: 

--- a/README.md
+++ b/README.md
@@ -33,23 +33,19 @@ A 2d [rapier](https://github.com/dimforge/rapier) physics server for [Godot Engi
 
 # Installation
 
-- Automatic (WIP)
 
-- Manual: 
+- Automatic (Recommended): Download the plugin from the official [Godot Asset Store](https://godotengine.org/asset-library/asset/2267) using the `AssetLib` tab in Godot.
 
-  a. Download the github release and move only the `addons` folder into your project `addons` folder. After installing, go to `Advanced Settings` -> `Physics` -> `2D`. Change `Physics Engine` to `Rapier2D`.
+- Manual: Download the github release and move only the `addons` folder into your project `addons` folder.
 
-  b. Build it yourself. Read more about it in the [documentation](DOCUMENTATION.MD).
+- Build it yourself. Read more about it in the [documentation](DOCUMENTATION.MD).
 
-## Use the Rapier 2D extension
-
-Copy the `addons/` folder to your project root.
+After installing, go to `Advanced Settings` -> `Physics` -> `2D`. Change `Physics Engine` to `Rapier2D`.
 
 # Roadmap
 
 - Cross Platform Determinism
-- Add more types of joints
-- Pass all Godot Physics Tests.
+- Fix all other issues from Limitations.
 
 # [Discord](https://discord.gg/56dMud8HYn)
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ A 2d [rapier](https://github.com/dimforge/rapier) physics server for [Godot Engi
 
 # Limitations
 
-- One way direction (WIP)
-- Spring Joint (WIP)
-- Static Body Constant Speed or Conveyer Belt (WIP)
-- Small issues with Character Controller (WIP)
+- One way direction missing(WIP)
+- Spring Joint missing(WIP)
+- Static Body Constant Speed or Conveyer Belt missing (WIP)
+- Shape scaling doesn't work (WIP)
+- Changing properties before they are added in world doesn't work (WIP)
 
 # Installation
 

--- a/src/rapier2d-wrapper/src/lib.rs
+++ b/src/rapier2d-wrapper/src/lib.rs
@@ -593,7 +593,9 @@ impl<'a> PhysicsHooks for PhysicsHooksCollisionFilter<'a> {
     }
 
     fn modify_solver_contacts(&self, context: &mut ContactModificationContext) {
-        *context.normal = -*context.normal;
+        // TODO implement conveyer belt
+        // for this we need to store the static object constant speed somewhere
+        /*
         if context.rigid_body1.is_none() || context.rigid_body2.is_none() {
             return;
         }
@@ -608,10 +610,13 @@ impl<'a> PhysicsHooks for PhysicsHooksCollisionFilter<'a> {
         if rigid_body2.is_fixed() && !rigid_body1.is_fixed() {
             (rigid_body2, rigid_body1) = (rigid_body1, rigid_body2);
         }
+        */
         // static and non static
-        if rigid_body1.is_fixed() && !rigid_body2.is_fixed() {
-            // TODO
-        }
+        //if rigid_body1.is_fixed() && !rigid_body2.is_fixed() {
+            for solver_contact in &mut *context.solver_contacts {
+                //solver_contact.tangent_velocity.x = 100.0;
+            }
+        //}
     }
 }
 
@@ -1009,7 +1014,22 @@ pub extern "C" fn shape_create_circle(radius : f32) -> Handle {
 
 #[no_mangle]
 pub extern "C" fn shape_create_capsule(half_height : f32, radius : f32) -> Handle {
-	let shape = SharedShape::capsule_y(half_height, radius);
+	let top_circle = SharedShape::ball(radius);
+    let top_circle_position = Isometry::new(vector![0.0, -half_height], 0.0);
+	let bottom_circle = SharedShape::ball(radius);
+    let bottom_circle_position = Isometry::new(vector![0.0, half_height], 0.0);
+	let square = SharedShape::cuboid(0.5 * radius, 0.5 * (half_height - radius));
+    let square_pos = Isometry::new(vector![0.0, 0.0], 0.0);
+    let mut shapes_vec = Vec::<(Isometry<Real>, SharedShape)>::new();
+    shapes_vec.push((top_circle_position, top_circle));
+    shapes_vec.push((bottom_circle_position, bottom_circle));
+    shapes_vec.push((square_pos, square));
+    let shape = SharedShape::compound(shapes_vec);
+    // For now create the shape using circles and squares as the default capsule is buggy
+    // in case of distance checking(returns invalid distances when close to the ends)
+    // overall results in a 1.33x decrease in performance
+    // TODO only do this in case of static objects?
+	//let shape = SharedShape::capsule_y(half_height, radius);
     let mut physics_engine = SINGLETON.lock().unwrap();
 	return physics_engine.insert_shape(shape);
 }
@@ -1070,7 +1090,7 @@ pub extern "C" fn collider_create_solid(world_handle : Handle, shape_handle : Ha
     collider.set_restitution_combine_rule(CoefficientCombineRule::Max);
     collider.set_density(0.0);
 	collider.user_data = user_data.get_data();
-	collider.set_active_hooks(ActiveHooks::FILTER_CONTACT_PAIRS & ActiveHooks::FILTER_INTERSECTION_PAIR & ActiveHooks::MODIFY_SOLVER_CONTACTS);
+	collider.set_active_hooks(ActiveHooks::FILTER_CONTACT_PAIRS | ActiveHooks::FILTER_INTERSECTION_PAIR | ActiveHooks::MODIFY_SOLVER_CONTACTS);
 	let physics_world = physics_engine.get_world(world_handle);
     return physics_world.insert_collider(collider, body_handle);
 }
@@ -1165,17 +1185,21 @@ pub extern "C" fn collider_set_contact_force_events_enabled(world_handle : Handl
 
 // Rigid body interface
 
-fn set_rigid_body_properties_internal(rigid_body : &mut RigidBody, pos : &Vector, rot : f32) {
-    rigid_body.set_rotation(Rotation::new(rot), false);
-    rigid_body.set_translation(vector![pos.x, pos.y], false);
+fn set_rigid_body_properties_internal(rigid_body : &mut RigidBody, pos : &Vector, rot : f32, wake_up : bool) {
+    if rigid_body.is_dynamic() {
+        rigid_body.set_rotation(Rotation::new(rot), wake_up);
+        rigid_body.set_translation(vector![pos.x, pos.y], wake_up);
+    } else {
+        rigid_body.set_next_kinematic_position(Isometry::new(vector![pos.x, pos.y], rot));
+    }
 }
 
 #[no_mangle]
 pub extern "C" fn body_create_fixed(world_handle : Handle, pos : &Vector, rot : f32, user_data : &UserData) -> Handle {
     let mut physics_engine = SINGLETON.lock().unwrap();
 	let physics_world = physics_engine.get_world(world_handle);
-    let mut rigid_body = RigidBodyBuilder::fixed().build();
-    set_rigid_body_properties_internal(&mut rigid_body, pos, rot);
+    let mut rigid_body = RigidBodyBuilder::kinematic_position_based().build();
+    set_rigid_body_properties_internal(&mut rigid_body, pos, rot, true);
 	rigid_body.user_data = user_data.get_data();
     let body_handle = physics_world.rigid_body_set.insert(rigid_body);
     return rigid_body_handle_to_handle(body_handle);
@@ -1190,7 +1214,7 @@ pub extern "C" fn body_create_dynamic(world_handle : Handle, pos : &Vector, rot 
 	activation.time_until_sleep = physics_world.sleep_time_until_sleep;
     activation.linear_threshold = physics_world.sleep_linear_threshold;
     activation.angular_threshold = physics_world.sleep_angular_threshold;
-    set_rigid_body_properties_internal(&mut rigid_body, pos, rot);
+    set_rigid_body_properties_internal(&mut rigid_body, pos, rot, false);
 	rigid_body.user_data = user_data.get_data();
     return physics_world.insert_rigid_body(rigid_body);
 }
@@ -1230,7 +1254,8 @@ pub extern "C" fn body_set_transform(world_handle : Handle, body_handle : Handle
     let rigid_body_handle = handle_to_rigid_body_handle(body_handle);
     let body = physics_world.rigid_body_set.get_mut(rigid_body_handle);
     assert!(body.is_some());
-    body.unwrap().set_position(Isometry::new(vector![pos.x, pos.y], rot), wake_up);
+    let body = body.unwrap();
+    set_rigid_body_properties_internal(body, pos, rot, wake_up);
 }
 
 #[no_mangle]
@@ -1818,13 +1843,8 @@ pub extern "C" fn shapes_contact(world_handle : Handle, shape_handle1 : Handle, 
     
     let mut result = ContactResult::new();
     if let Ok(Some(contact)) = parry::query::contact(
-        &shape_transform1, shared_shape1.as_ref(), &shape_transform2, shared_shape2.as_ref(), prediction * 1.5
+        &shape_transform1, shared_shape1.as_ref(), &shape_transform2, shared_shape2.as_ref(), prediction
     ) {
-        // we used at contact a bigger number, prediction * 1.5 in order to increase search range.
-        // now check if we are actually within the margin, if not, return no intersection.
-        if contact.dist > prediction {
-            return result;
-        }
         // the distance is negative if there is intersection
         // and positive if the objects are separated by distance less than margin
         result.distance = contact.dist;

--- a/src/rapier_body_2d.cpp
+++ b/src/rapier_body_2d.cpp
@@ -1179,10 +1179,12 @@ Rect2 RapierBody2D::get_aabb() {
 			continue;
 		}
 		if (!shapes_found) {
-			body_aabb = get_shape(i)->get_aabb();
+			// TODO not 100% correct, we don't take into consideration rotation here.
+			body_aabb = get_shape(i)->get_aabb(get_shape_transform(i).get_origin());
 			shapes_found = true;
 		} else {
-			body_aabb = body_aabb.merge(get_shape(i)->get_aabb());
+			// TODO not 100% correct, we don't take into consideration rotation here.
+			body_aabb = body_aabb.merge(get_shape(i)->get_aabb(get_shape_transform(i).get_origin()));
 		}
 	}
 	return body_aabb;

--- a/src/rapier_body_utils_2d.cpp
+++ b/src/rapier_body_utils_2d.cpp
@@ -212,7 +212,7 @@ void RapierBodyUtils2D::cast_motion(
 				//rapier2d::Vector rapier_body_shape_pos{ body_shape_pos.x + p_motion.x, body_shape_pos.y + p_motion.y };
 				//rapier2d::ContactResult step_contact = rapier2d::shapes_contact(p_space.get_handle(), body_shape_handle, &rapier_body_shape_pos, body_shape_rot, col_shape_handle, &rapier_col_shape_pos, rapier_col_shape_rot, 0.0);
 				//if (!step_contact.collided || (step_contact.collided && step_contact.within_margin)) {
-					//continue;
+				//continue;
 				//}
 			}
 

--- a/src/rapier_body_utils_2d.cpp
+++ b/src/rapier_body_utils_2d.cpp
@@ -4,7 +4,6 @@
 #include "rapier_space_2d.h"
 
 #define TEST_MOTION_MIN_CONTACT_DEPTH_FACTOR 0.05
-#define SMALL_MARGIN_FOR_NUMERICAL_ERRORS 0.1
 #define BODY_MOTION_RECOVER_ATTEMPTS 4
 #define BODY_MOTION_RECOVER_RATIO 0.4
 
@@ -200,7 +199,7 @@ void RapierBodyUtils2D::cast_motion(
 			{
 				// stuck logic, check if body collides in place
 				rapier2d::Vector rapier_body_shape_step_pos_initial{ body_shape_pos.x, body_shape_pos.y };
-				rapier2d::ContactResult step_contact = rapier2d::shapes_contact(p_space.get_handle(), body_shape_handle, &rapier_body_shape_step_pos_initial, body_shape_rot, col_shape_handle, &rapier_col_shape_pos, rapier_col_shape_rot, SMALL_MARGIN_FOR_NUMERICAL_ERRORS);
+				rapier2d::ContactResult step_contact = rapier2d::shapes_contact(p_space.get_handle(), body_shape_handle, &rapier_body_shape_step_pos_initial, body_shape_rot, col_shape_handle, &rapier_col_shape_pos, rapier_col_shape_rot, 0.0);
 				if (step_contact.collided && !step_contact.within_margin) {
 					p_closest_safe = 0;
 					p_closest_unsafe = 0;
@@ -210,11 +209,11 @@ void RapierBodyUtils2D::cast_motion(
 			}
 			{
 				// no collision logic at end of motion. Disabling this as it seems to cause jitter
-				//rapier2d::Vector rapier_body_shape_pos{ body_shape_pos.x + p_motion.x, body_shape_pos.y + p_motion.y };
-				//rapier2d::ContactResult step_contact = rapier2d::shapes_contact(p_space.get_handle(), body_shape_handle, &rapier_body_shape_pos, body_shape_rot, col_shape_handle, &rapier_col_shape_pos, rapier_col_shape_rot, SMALL_MARGIN_FOR_NUMERICAL_ERRORS);
-				//if (!step_contact.collided || (step_contact.collided && step_contact.within_margin)) {
-				//continue;
-				//}
+				rapier2d::Vector rapier_body_shape_pos{ body_shape_pos.x + p_motion.x, body_shape_pos.y + p_motion.y };
+				rapier2d::ContactResult step_contact = rapier2d::shapes_contact(p_space.get_handle(), body_shape_handle, &rapier_body_shape_pos, body_shape_rot, col_shape_handle, &rapier_col_shape_pos, rapier_col_shape_rot, 0.0);
+				if (!step_contact.collided || (step_contact.collided && step_contact.within_margin)) {
+					continue;
+				}
 			}
 
 			//just do kinematic solving
@@ -234,7 +233,7 @@ void RapierBodyUtils2D::cast_motion(
 				real_t fraction = low + (hi - low) * fraction_coeff;
 
 				rapier2d::Vector rapier_body_shape_step_pos{ body_shape_pos.x + p_motion.x * fraction, body_shape_pos.y + p_motion.y * fraction };
-				rapier2d::ContactResult step_contact = rapier2d::shapes_contact(p_space.get_handle(), body_shape_handle, &rapier_body_shape_step_pos, body_shape_rot, col_shape_handle, &rapier_col_shape_pos, rapier_col_shape_rot, SMALL_MARGIN_FOR_NUMERICAL_ERRORS);
+				rapier2d::ContactResult step_contact = rapier2d::shapes_contact(p_space.get_handle(), body_shape_handle, &rapier_body_shape_step_pos, body_shape_rot, col_shape_handle, &rapier_col_shape_pos, rapier_col_shape_rot, 0.0);
 				if (step_contact.collided && !step_contact.within_margin) {
 					hi = fraction;
 					if ((k == 0) || (low > 0.0)) { // Did it not collide before?

--- a/src/rapier_body_utils_2d.cpp
+++ b/src/rapier_body_utils_2d.cpp
@@ -209,11 +209,11 @@ void RapierBodyUtils2D::cast_motion(
 			}
 			{
 				// no collision logic at end of motion. Disabling this as it seems to cause jitter
-				rapier2d::Vector rapier_body_shape_pos{ body_shape_pos.x + p_motion.x, body_shape_pos.y + p_motion.y };
-				rapier2d::ContactResult step_contact = rapier2d::shapes_contact(p_space.get_handle(), body_shape_handle, &rapier_body_shape_pos, body_shape_rot, col_shape_handle, &rapier_col_shape_pos, rapier_col_shape_rot, 0.0);
-				if (!step_contact.collided || (step_contact.collided && step_contact.within_margin)) {
-					continue;
-				}
+				//rapier2d::Vector rapier_body_shape_pos{ body_shape_pos.x + p_motion.x, body_shape_pos.y + p_motion.y };
+				//rapier2d::ContactResult step_contact = rapier2d::shapes_contact(p_space.get_handle(), body_shape_handle, &rapier_body_shape_pos, body_shape_rot, col_shape_handle, &rapier_col_shape_pos, rapier_col_shape_rot, 0.0);
+				//if (!step_contact.collided || (step_contact.collided && step_contact.within_margin)) {
+					//continue;
+				//}
 			}
 
 			//just do kinematic solving

--- a/src/rapier_collision_object_2d.cpp
+++ b/src/rapier_collision_object_2d.cpp
@@ -248,15 +248,15 @@ void RapierCollisionObject2D::_update_shape_transform(const Shape &shape) {
 	}
 
 	rapier2d::Handle space_handle = space->get_handle();
-	ERR_FAIL_COND(!rapier2d::is_handle_valid(space_handle));
-
-	ERR_FAIL_COND(!rapier2d::is_handle_valid(shape.collider_handle));
 
 	const Vector2 &origin = shape.xform.get_origin();
 	rapier2d::Vector position = { origin.x, origin.y };
 	real_t angle = shape.xform.get_rotation();
 
 	shape.shape->apply_rapier_transform(position, angle);
+	ERR_FAIL_COND(!rapier2d::is_handle_valid(space_handle));
+
+	ERR_FAIL_COND(!rapier2d::is_handle_valid(shape.collider_handle));
 
 	rapier2d::collider_set_transform(space_handle, shape.collider_handle, &position, angle);
 }

--- a/src/rapier_shape_2d.h
+++ b/src/rapier_shape_2d.h
@@ -45,7 +45,11 @@ public:
 
 	rapier2d::Handle get_rapier_shape();
 
-	_FORCE_INLINE_ Rect2 get_aabb() const { return aabb; }
+	_FORCE_INLINE_ Rect2 get_aabb(Vector2 origin = Vector2()) const {
+		Rect2 aabb_clone = aabb;
+		aabb_clone.position += origin;
+		return aabb_clone;
+	}
 	_FORCE_INLINE_ bool is_configured() const { return configured; }
 
 	void add_owner(RapierShapeOwner2D *p_owner);


### PR DESCRIPTION
- Change capsule to basic shapes. This helps the test_body_move but makes everything about 1.33x slower(we can see later to only make the shapes like this for static bodies).
- Add basic implementation for conveyer belt. (a little bit of boiler plate that we can use later).
- Make static bodies be kinematic instead. (this is needed also for Godot so we are able to return the velocity correctly. Also, rapier handles moving static shapes better if they are kinematic instead of static).
- Update how we construct aabb's to keep into account position of shapes also(we still need to update based on rotation, for that I think we need to recreate the aabb completely. Also scaling, etc).
- remove the `SMALL_MARGIN_FOR_NUMERICAL_ERRORS` as it seems to only be relevant for capsule that now works.
- Move an error related to if a shape is not in a space when set_transform is called. We need to make sure also that updates are applied correctly for everything even if things aren't in simulation(big change, todo)