### PR TITLE
fix scaling to work.

### DIFF
--- a/src/bodies/rapier_collision_object_2d.cpp
+++ b/src/bodies/rapier_collision_object_2d.cpp
@@ -251,15 +251,17 @@ void RapierCollisionObject2D::_update_shape_transform(const Shape &shape) {
 	rapier2d::Handle space_handle = space->get_handle();
 
 	const Vector2 &origin = shape.xform.get_origin();
+	const Vector2 &scale = shape.xform.get_scale();
 	rapier2d::Vector position = { origin.x, origin.y };
+	rapier2d::Vector rapier_scale = { scale.x, scale.y };
 	real_t angle = shape.xform.get_rotation();
 
 	shape.shape->apply_rapier_transform(position, angle);
 	ERR_FAIL_COND(!rapier2d::is_handle_valid(space_handle));
 
 	ERR_FAIL_COND(!rapier2d::is_handle_valid(shape.collider_handle));
-
-	rapier2d::collider_set_transform(space_handle, shape.collider_handle, &position, angle);
+	ERR_FAIL_COND(!rapier2d::is_handle_valid(shape.shape->get_rapier_shape()));
+	rapier2d::collider_set_transform(space_handle, shape.collider_handle, shape.shape->get_rapier_shape(), &position, angle, &rapier_scale);
 }
 
 void RapierCollisionObject2D::_set_space(RapierSpace2D *p_space) {

--- a/src/rapier2d-wrapper/includes/rapier2d_wrapper.h
+++ b/src/rapier2d-wrapper/includes/rapier2d_wrapper.h
@@ -330,7 +330,12 @@ void collider_set_collision_events_enabled(Handle world_handle, Handle handle, b
 
 void collider_set_contact_force_events_enabled(Handle world_handle, Handle handle, bool enable);
 
-void collider_set_transform(Handle world_handle, Handle handle, const Vector *pos, Real rot);
+void collider_set_transform(Handle world_handle,
+		Handle handle,
+		Handle shape_handle,
+		const Vector *pos,
+		Real rot,
+		const Vector *scale);
 
 Material default_material();
 


### PR DESCRIPTION
- Fixes https://github.com/fabriceci/godot-rapier2d/issues/47
Scaling was never applied to shapes. This applies it by modifying the shape. Could be extended to work with skewing maybe. Will investigate.